### PR TITLE
Load custom font on main style and preload on head index

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,41 +13,6 @@
     <!-- Google tag (gtag.js) -->
     <title>Betso88</title>
     <style>   
-      @font-face {
-          font-family: 'Poppins';
-          src: url('./src/assets/font/Poppins-Thin.woff2') format('woff2');
-          font-weight: thin;
-          font-style: normal;
-          font-display: block;
-      }
-      @font-face {
-          font-family: 'Poppins';
-          src: url('./src/assets/font/Poppins-Light.woff2') format('woff2');
-          font-weight: light;
-          font-style: normal;
-          font-display: block;
-      }
-      @font-face {
-          font-family: 'Poppins';
-          src: url('./src/assets/font/Poppins-Regular.woff2') format('woff2');
-          font-weight: normal;
-          font-style: normal;
-          font-display: block;
-      }
-      @font-face {
-          font-family: 'Poppins';
-          src: url('./src/assets/font/Poppins-Medium.woff2') format('woff2');
-          font-weight: medium;
-          font-style: normal;
-          font-display: block;
-      }
-      @font-face {
-          font-family: 'Poppins';
-          src: url('./src/assets/font/Poppins-Bold.woff2') format('woff2');
-          font-weight: bold;
-          font-style: normal;
-          font-display: block;
-      }
 
       p.my-4.text-xl.text-white {
           font-family: 'Poppins', sans-serif;

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -2,6 +2,42 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+    font-family: 'Poppins';
+    font-weight: thin;
+    font-style: normal;
+    font-display: swap;
+    src: url('./font/Poppins-Thin.woff2') format('woff2');
+}
+@font-face {
+    font-family: 'Poppins';
+    font-weight: light;
+    font-style: normal;
+    font-display: swap;
+    src: url('./font/Poppins-Light.woff2') format('woff2');
+}
+@font-face {
+    font-family: 'Poppins';
+    font-weight: normal;
+    font-style: normal;
+    font-display: swap;
+    src: url('./font/Poppins-Regular.woff2') format('woff2');
+}
+@font-face {
+    font-family: 'Poppins';
+    font-weight: medium;
+    font-style: normal;
+    font-display: swap;
+    src: url('./font/Poppins-Medium.woff2') format('woff2');
+}
+@font-face {
+    font-family: 'Poppins';
+    font-weight: bold;
+    font-style: normal;
+    font-display: swap;
+    src: url('./font/Poppins-Bold.woff2') format('woff2');
+}
+
 
 /* @font-face {
     font-family: 'Poppins';


### PR DESCRIPTION
To fix render blocking on styles. 

 In server:
 
 Need to change ```index.html``` file after build. comment the link css inside the head
 ```html
<head>
     <!-- <link rel="stylesheet" crossorigin href="/assets/index-arATopZp.css"> -->
</head>
```
  And change with these instead:
```html
  <link rel="preload" href="/assets/index-[ random string ].css" as="style" onload="this.onload=null;this.rel='stylesheet'">
    <noscript><link rel="stylesheet" href="/assets/index-[ random string].css"></noscript>
```

To fill the random string, on your dist folder find the link css and copy the generated random string. The random string is generated after build

example:
```html
<head>
<!-- <link rel="stylesheet" crossorigin href="/assets/index-rAmDomStrInG.css"> -->
<link rel="preload" href="/assets/index-rAmDomStrInG.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
    <noscript><link rel="stylesheet" href="/assets/index-rAmDomStrInG.css"></noscript>
</head>
```
